### PR TITLE
Multi-NIC Added callback when new client connection is accepted

### DIFF
--- a/include/zmq.h
+++ b/include/zmq.h
@@ -224,6 +224,7 @@ ZMQ_EXPORT int zmq_ctx_destroy (void *context);
  * SPARC and ARM
  */
 typedef union zmq_msg_t { unsigned char _ [64]; void *p; } zmq_msg_t;
+typedef void (*accept_callback_fn)(void *, zmq_id, const char *);
 
 struct zmq_content {
         void *_private[7];
@@ -345,6 +346,7 @@ ZMQ_EXPORT void *zmq_msg_push(zmq_msg_t *msg, size_t len);
 #define ZMQ_XPUB_NODROP 69
 #define ZMQ_RECV_CALLBACK 70
 #define ZMQ_DECODER_OPS 71
+#define ZMQ_ACCEPT_CALLBACK 72
 
 #ifdef __cplusplus
 
@@ -354,6 +356,12 @@ class msg_t;
 
 struct recv_callback_arg {
 	void (*func)(void *ctx, zmq::msg_t *msg);
+
+	void *ctx;
+};
+
+struct accept_callback_arg {
+	void (*func)(void *ctx, zmq_id id, const char *addr);
 
 	void *ctx;
 };

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -68,7 +68,9 @@ zmq::options_t::options_t () :
     handshake_ivl (30000),
     recv_callback(NULL),
     recv_callback_arg(NULL),
-    has_decoder_ops(false)
+    has_decoder_ops(false),
+    accept_callback(NULL),
+    accept_callback_arg(NULL)
 {
     memset (curve_public_key, 0, CURVE_KEYSIZE);
     memset (curve_secret_key, 0, CURVE_KEYSIZE);

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -188,6 +188,9 @@ namespace zmq
 
         bool has_decoder_ops;
         decoder_ops dec_ops;
+
+	accept_callback_fn accept_callback; 
+        void *accept_callback_arg;
     };
 }
 

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -591,6 +591,17 @@ int
 zmq::px_server::xsetsockopt(int option_, const void *optval_, size_t optvallen_)
 {
     switch (option_) {
+    case ZMQ_ACCEPT_CALLBACK: {
+        if (optvallen_ != sizeof(zmq::accept_callback_arg)) {
+            errno = EINVAL;
+            return -1;
+        }
+        const zmq::accept_callback_arg *arg =
+                reinterpret_cast<const zmq::accept_callback_arg *>(optval_);
+        options.accept_callback = arg->func;
+        options.accept_callback_arg = arg->ctx;
+        return 0;
+    }
     case ZMQ_RECV_CALLBACK: {
         if (optvallen_ != sizeof(zmq::recv_callback_arg)) {
             errno = EINVAL;

--- a/src/stream_engine.cpp
+++ b/src/stream_engine.cpp
@@ -814,9 +814,10 @@ int zmq::stream_engine_t::process_handshake_command (msg_t *msg_)
 	    if (!options.has_decoder_ops) {
 		    msg_->init();
 	    }
-        if (mechanism->status () == mechanism_t::ready)
+        if (mechanism->status () == mechanism_t::ready) {
             mechanism_ready ();
-        else
+        }
+	else
         if (mechanism->status () == mechanism_t::error) {
             errno = EPROTO;
             return -1;
@@ -850,6 +851,8 @@ void zmq::stream_engine_t::mechanism_ready ()
         mechanism->peer_identity (&identity);
         if (sizeof(id_) - 1 >= identity.size()) {
             set_id(id_, identity.data(), identity.size());
+	    if (id_ > 0 && options.accept_callback)
+                options.accept_callback(options.accept_callback_arg, id_, endpoint.c_str());
         }
 
         const int rc = session->push_msg (&identity);


### PR DESCRIPTION
Added ZMQ_ACCEPT_CALLBACK, which will be called for incoming connections.
Messenger will open response path using same path-id and ip address