### PR TITLE
Added callback for connect event

### DIFF
--- a/src/tcp_connecter.cpp
+++ b/src/tcp_connecter.cpp
@@ -149,6 +149,10 @@ void zmq::tcp_connecter_t::out_event ()
     terminate ();
 
     socket->event_connected (endpoint, fd);
+    if (options.zmq_callback.accept_callback) {
+        options.zmq_callback.accept_callback(options.zmq_callback.ctx, zmq_id(), nullptr);
+    }
+
 }
 
 void zmq::tcp_connecter_t::timer_event (int id_)


### PR DESCRIPTION
In the fix for fast-nodedown detection connection state is updated as connected immediately after open socket.
State should be set to connected only after connect event. Callback get called for umq, but was missing for zmq